### PR TITLE
JFreeChart package and configuration fixes

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -130,6 +130,8 @@
         </javac>
     </target>
 
+    <target name="rebuild" depends="clean,xar"/>
+
     <target name="jar" depends="compile" description="Create JAR file">
         <jar basedir="${java.classes}"
             jarfile="${build.dir}/exist-${module.name}-${module.version}.jar">
@@ -151,8 +153,8 @@
 
         <!-- create library -->
         <zip destfile="${dist.dir}/${module.name}-${module.version}.xar">
-            <zipfileset dir="${build.dir}" includes="*.jar" prefix="jfreechart"/>
-            <zipfileset dir="${java.libs}" prefix="jfreechart">
+            <zipfileset dir="${build.dir}" includes="*.jar" prefix="content"/>
+            <zipfileset dir="${java.libs}" prefix="content">
                 <include name="*.jar"/>
                 <exclude name="*-javadoc.jar"/>
                 <exclude name="*-sources.jar"/>

--- a/config/library/repo.xml.tmpl
+++ b/config/library/repo.xml.tmpl
@@ -2,6 +2,7 @@
 <meta xmlns="http://exist-db.org/xquery/repo">
     <description>@TITLE@</description>
     <author>Dannes Wessels</author>
+    <author>Leif-Jöran Olsson</author>
     <website>https://github.com/eXist-db/jfreechart</website>
     <status>beta</status>
     <license>GNU-LGPL</license>

--- a/java/src/org/exist/xquery/modules/jfreechart/Configuration.java
+++ b/java/src/org/exist/xquery/modules/jfreechart/Configuration.java
@@ -246,7 +246,7 @@ public class Configuration {
 
                     // Verify that value is found
                     if (value == null) {
-                        throw new XPathException(MessageFormat.format("Value for '{0}' cannot be parsed", localName));
+                        throw new XPathException(MessageFormat.format("Value for \"{0}\" cannot be parsed", localName));
                     }
 
                     switch (localName) {
@@ -294,7 +294,7 @@ public class Configuration {
                                 orientation = PlotOrientation.VERTICAL;
 
                             } else {
-                                throw new XPathException(MessageFormat.format("Wrong value for '{0}'", localName));
+                                throw new XPathException(MessageFormat.format("Wrong value for \"{0}\"", localName));
                             }
                             verifyValue(localName, orientation);
                             break;
@@ -306,7 +306,7 @@ public class Configuration {
                                 order = TableOrder.BY_ROW;
 
                             } else {
-                                throw new XPathException(MessageFormat.format("Wrong value for '{0}'", localName));
+                                throw new XPathException(MessageFormat.format("Wrong value for \"{0}\"", localName));
                             }
                             verifyValue(localName, order);
                             break;
@@ -367,7 +367,7 @@ public class Configuration {
 
                         case "rangeUpperBound":
                             rangeUpperBound = parseDouble(value);
-                            verifyValue(localName, rangeAxisLabel);
+                            verifyValue(localName, rangeUpperBound);
                             break;
 
                         case "categoryItemLabelGeneratorClass":
@@ -393,7 +393,7 @@ public class Configuration {
                                 categoryLabelPositions = CategoryLabelPositions.DOWN_90;
 
                             } else {
-                                throw new XPathException(MessageFormat.format("Wrong value for '{0}'", localName));
+                                throw new XPathException(MessageFormat.format("Wrong value for \"{0}\"", localName));
                             }
                             verifyValue(localName, categoryLabelPositions);
                             break;
@@ -472,7 +472,7 @@ public class Configuration {
      */
     private void verifyValue(String localName, Object convertedValue) throws XPathException {
         if (convertedValue == null) {
-            throw new XPathException(MessageFormat.format("Unable to convert value of '{0}'", localName));
+	    throw new XPathException(MessageFormat.format("Unable to convert value of \"{0}\"", localName));
         }
     }
 }

--- a/java/src/org/exist/xquery/modules/jfreechart/Configuration.java
+++ b/java/src/org/exist/xquery/modules/jfreechart/Configuration.java
@@ -94,6 +94,8 @@ public class Configuration {
     private boolean generateTooltips = false;
     private boolean generateUrls = false;
 
+    private boolean onlyShape = false;
+
     // =========================
     // Getters
     public String getImageType() {
@@ -126,6 +128,10 @@ public class Configuration {
 
     public boolean isGenerateUrls() {
         return generateUrls;
+    }
+
+    public boolean isOnlyShape() {
+        return onlyShape;
     }
 
     public PlotOrientation getOrientation() {
@@ -324,6 +330,11 @@ public class Configuration {
                         case "urls":
                             generateUrls = parseBoolean(value);
                             verifyValue(localName, generateUrls);
+                            break;
+
+                        case "onlyShape":
+                            onlyShape = parseBoolean(value);
+                            verifyValue(localName, onlyShape);
                             break;
 
                         case "width":

--- a/java/src/org/exist/xquery/modules/jfreechart/JFreeChartFactory.java
+++ b/java/src/org/exist/xquery/modules/jfreechart/JFreeChartFactory.java
@@ -42,6 +42,7 @@ import org.jfree.chart.plot.MultiplePiePlot;
 import org.jfree.chart.plot.PiePlot;
 import org.jfree.chart.plot.SpiderWebPlot;
 import org.jfree.chart.renderer.category.CategoryItemRenderer;
+import org.jfree.chart.renderer.category.LineAndShapeRenderer;
 import org.jfree.chart.title.LegendTitle;
 import org.jfree.chart.title.TextTitle;
 import org.jfree.data.category.CategoryDataset;
@@ -252,6 +253,7 @@ public class JFreeChartFactory {
     
     
     private static void setCategoryChartParameters(JFreeChart chart, Configuration config) throws XPathException {
+	setRenderer(chart, config);
         setCategoryRange(chart, config);
         setCategoryItemLabelGenerator(chart, config);
         setCategoryLabelPositions(chart, config);
@@ -259,7 +261,12 @@ public class JFreeChartFactory {
         setAxisColors(chart, config);
     }
     
-    
+    private static void setRenderer(JFreeChart chart, Configuration config) {
+	if (chart.getPlot() instanceof CategoryPlot && config.isOnlyShape()) {
+	    CategoryItemRenderer renderer = new LineAndShapeRenderer(false, true);
+	    ((CategoryPlot) chart.getPlot()).setRenderer(renderer);
+	}
+    }
     private static void setCategoryRange(JFreeChart chart, Configuration config) {
         Double rangeLowerBound = config.getRangeLowerBound();
         Double rangeUpperBound = config.getRangeUpperBound();


### PR DESCRIPTION
- Fixing exception messages where {0} variables were not expanded and rangeUpperBound check and handling in configuration.
- Change prefix to content instead of jfreechart to match expath package location and avoid warning of old-style content directory.
- Adding boolean onlyShape to configuration options to disable line drawing for CategoryPlot to look like a scatterplot if needed until XYPlot is ready.
