### PR TITLE
Adding support for new XYDataset and XYZDataset charts.

### DIFF
--- a/java/src/org/exist/xquery/modules/jfreechart/Configuration.java
+++ b/java/src/org/exist/xquery/modules/jfreechart/Configuration.java
@@ -1,6 +1,6 @@
 /*
  *  eXist Open Source Native XML Database
- *  Copyright (C) 2009-2013 The eXist-db Project
+ *  Copyright (C) 2009-2014 The eXist-db Project
  *  http://exist-db.org
  *
  *  This program is free software; you can redistribute it and/or
@@ -45,6 +45,10 @@ public class Configuration {
     private int imageHeight = 300;
     private int imageWidth = 400;
 
+    // for XYDotRenderer
+    private int dotHeight = 1;
+    private int dotWidth = 1;
+
     // Chart title
     private String title;
 
@@ -88,6 +92,17 @@ public class Configuration {
     // Range  
     private Double rangeLowerBound;
     private Double rangeUpperBound;
+    private Double rangeLowerMargin;
+    private Double rangeUpperMargin;
+
+    // Domain
+    private Double domainLowerBound;
+    private Double domainUpperBound;
+    private Double domainLowerMargin;
+    private Double domainUpperMargin;
+
+    // Alpha
+    private Float foregroundAlpha;
 
     // Misc flags
     private boolean generateLegend = false;
@@ -95,6 +110,15 @@ public class Configuration {
     private boolean generateUrls = false;
 
     private boolean onlyShape = false;
+
+    private boolean rangeAutoRangeIncludesZero = true;
+    private boolean domainAutoRangeIncludesZero = true;
+    private boolean rangeZeroBaselineVisible = true;
+    private boolean domainZeroBaselineVisible = true;
+    private boolean rangeIntegerTickUnits = false;
+    private boolean domainIntegerTickUnits = false;
+    private boolean rangeGridlinesVisible = false;
+    private boolean domainGridlinesVisible = false;
 
     // =========================
     // Getters
@@ -134,6 +158,38 @@ public class Configuration {
         return onlyShape;
     }
 
+    public boolean isRangeAutoRangeIncludesZero() {
+        return rangeAutoRangeIncludesZero;
+    }
+
+    public boolean isDomainAutoRangeIncludesZero() {
+        return domainAutoRangeIncludesZero;
+    }
+
+    public boolean isRangeZeroBaselineVisible() {
+        return rangeZeroBaselineVisible;
+    }
+
+    public boolean isDomainZeroBaselineVisible() {
+        return domainZeroBaselineVisible;
+    }
+
+    public boolean isRangeIntegerTickUnits() {
+        return rangeIntegerTickUnits;
+    }
+
+    public boolean isDomainIntegerTickUnits() {
+        return domainIntegerTickUnits;
+    }
+
+    public boolean isRangeGridlinesVisible() {
+        return rangeGridlinesVisible;
+    }
+
+    public boolean isDomainGridlinesVisible() {
+        return domainGridlinesVisible;
+    }
+
     public PlotOrientation getOrientation() {
         return orientation;
     }
@@ -160,6 +216,14 @@ public class Configuration {
 
     public int getImageWidth() {
         return imageWidth;
+    }
+
+    public int getDotHeight() {
+        return dotHeight;
+    }
+
+    public int getDotWidth() {
+        return dotWidth;
     }
 
     public String getDomainAxisLabel() {
@@ -200,6 +264,34 @@ public class Configuration {
 
     public Double getRangeUpperBound() {
         return rangeUpperBound;
+    }
+
+    public Double getRangeLowerMargin() {
+        return rangeLowerMargin;
+    }
+
+    public Double getRangeUpperMargin() {
+        return rangeUpperMargin;
+    }
+
+    public Double getDomainLowerBound() {
+        return domainLowerBound;
+    }
+
+    public Double getDomainUpperBound() {
+        return domainUpperBound;
+    }
+
+    public Double getDomainLowerMargin() {
+        return domainLowerMargin;
+    }
+
+    public Double getDomainUpperMargin() {
+        return domainUpperMargin;
+    }
+
+    public Float getForegroundAlpha() {
+        return foregroundAlpha;
     }
 
     public String getCategoryItemLabelGeneratorClass() {
@@ -337,6 +429,46 @@ public class Configuration {
                             verifyValue(localName, onlyShape);
                             break;
 
+                        case "rangeAutoRangeIncludesZero":
+                            rangeAutoRangeIncludesZero = parseBoolean(value);
+                            verifyValue(localName, rangeAutoRangeIncludesZero);
+                            break;
+
+                        case "domainAutoRangeIncludesZero":
+                            domainAutoRangeIncludesZero = parseBoolean(value);
+                            verifyValue(localName, domainAutoRangeIncludesZero);
+                            break;
+
+                        case "rangeIntegerTickUnits":
+                            rangeIntegerTickUnits = parseBoolean(value);
+                            verifyValue(localName, rangeIntegerTickUnits);
+                            break;
+
+                        case "domainIntegerTickUnits":
+                            domainIntegerTickUnits = parseBoolean(value);
+                            verifyValue(localName, domainIntegerTickUnits);
+                            break;
+
+                        case "rangeGridlinesVisible":
+                            rangeGridlinesVisible = parseBoolean(value);
+                            verifyValue(localName, rangeGridlinesVisible);
+                            break;
+
+                        case "domainGridlinesVisible":
+                            domainGridlinesVisible = parseBoolean(value);
+                            verifyValue(localName, domainGridlinesVisible);
+                            break;
+
+                        case "rangeZeroBaselineVisible":
+                            rangeZeroBaselineVisible = parseBoolean(value);
+                            verifyValue(localName, rangeZeroBaselineVisible);
+                            break;
+
+                        case "domainZeroBaselineVisible":
+                            domainZeroBaselineVisible = parseBoolean(value);
+                            verifyValue(localName, domainZeroBaselineVisible);
+                            break;
+
                         case "width":
                             imageWidth = parseInteger(value);
                             verifyValue(localName, imageWidth);
@@ -345,6 +477,16 @@ public class Configuration {
                         case "height":
                             imageHeight = parseInteger(value);
                             verifyValue(localName, imageHeight);
+                            break;
+
+                        case "dotWidth":
+                            dotWidth = parseInteger(value);
+                            verifyValue(localName, dotWidth);
+                            break;
+
+                        case "dotHeight":
+                            dotHeight = parseInteger(value);
+                            verifyValue(localName, dotHeight);
                             break;
 
                         case "titleColor":
@@ -379,6 +521,41 @@ public class Configuration {
                         case "rangeUpperBound":
                             rangeUpperBound = parseDouble(value);
                             verifyValue(localName, rangeUpperBound);
+                            break;
+
+                        case "rangeLowerMargin":
+                            rangeLowerMargin = parseDouble(value);
+                            verifyValue(localName, rangeLowerMargin);
+                            break;
+
+                        case "rangeUpperMargin":
+                            rangeUpperMargin = parseDouble(value);
+                            verifyValue(localName, rangeUpperMargin);
+                            break;
+
+                        case "domainLowerBound":
+                            domainLowerBound = parseDouble(value);
+                            verifyValue(localName, domainLowerBound);
+                            break;
+
+                        case "domainUpperBound":
+                            domainUpperBound = parseDouble(value);
+                            verifyValue(localName, domainUpperBound);
+                            break;
+
+                        case "domainLowerMargin":
+                            domainLowerMargin = parseDouble(value);
+                            verifyValue(localName, domainLowerMargin);
+                            break;
+
+                        case "domainUpperMargin":
+                            domainUpperMargin = parseDouble(value);
+                            verifyValue(localName, domainUpperMargin);
+                            break;
+
+                        case "foregroundAlpha":
+                            foregroundAlpha = parseFloat(value);
+                            verifyValue(localName, foregroundAlpha);
                             break;
 
                         case "categoryItemLabelGeneratorClass":
@@ -460,6 +637,21 @@ public class Configuration {
 
         try {
             return Double.valueOf(value);
+
+        } catch (NumberFormatException ex) {
+            logger.debug(ex.getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * Parse text and return Float. NULL is returned when value cannot be
+     * converted.
+     */
+    private Float parseFloat(String value) {
+
+        try {
+            return Float.valueOf(value);
 
         } catch (NumberFormatException ex) {
             logger.debug(ex.getMessage());

--- a/java/src/org/exist/xquery/modules/jfreechart/JFreeChartFactory.java
+++ b/java/src/org/exist/xquery/modules/jfreechart/JFreeChartFactory.java
@@ -51,6 +51,7 @@ import org.jfree.data.category.CategoryDataset;
 import org.jfree.data.general.PieDataset;
 import org.jfree.data.xml.DatasetReader;
 import org.jfree.data.xml.XYDatasetReader;
+import org.jfree.data.xy.IntervalXYDataset;
 import org.jfree.data.xy.XYDataset;
 import org.jfree.data.xy.XYZDataset;
 import org.jfree.ui.RectangleEdge;
@@ -91,7 +92,7 @@ public class JFreeChartFactory {
                 logger.debug("Reading XML PieDataset");
                 pieDataset = DatasetReader.readPieDatasetFromXML(is);
 
-            } else if ("ScatterPlot".equals(chartType) || "XYLineChart".equals(chartType)) {
+            } else if ("ScatterPlot".equals(chartType) || "XYAreaChart".equals(chartType) || "XYBarChart".equals(chartType) || "XYLineChart".equals(chartType)) {
                 logger.debug("Reading XML XYDataset");
                 XYDataset = XYDatasetReader.readXYDatasetFromXML(is);
             } else if ("BubbleChart".equals(chartType)) {
@@ -256,6 +257,21 @@ public class JFreeChartFactory {
 
                 //setCategoryChartParameters(chart, conf);
                 break;
+            case "XYAreaChart":
+                chart = ChartFactory.createXYAreaChart(
+                        conf.getTitle(), conf.getCategoryAxisLabel(), conf.getValueAxisLabel(), XYDataset,
+                        conf.getOrientation(), conf.isGenerateLegend(), conf.isGenerateTooltips(), conf.isGenerateUrls());
+
+                //setCategoryChartParameters(chart, conf);
+                break;
+            case "XYBarChart":
+                chart = ChartFactory.createXYBarChart(
+			conf.getTitle(), conf.getCategoryAxisLabel(), true,
+			conf.getValueAxisLabel(), (IntervalXYDataset) XYDataset,
+                        conf.getOrientation(), conf.isGenerateLegend(), conf.isGenerateTooltips(), conf.isGenerateUrls());
+
+                //setCategoryChartParameters(chart, conf);
+                break;
             case "XYLineChart":
                 chart = ChartFactory.createXYLineChart(
                         conf.getTitle(), conf.getCategoryAxisLabel(), conf.getValueAxisLabel(), XYDataset,
@@ -281,10 +297,13 @@ public class JFreeChartFactory {
 
             default:
                 logger.error("Illegal chart type. Choose one of "
-                        + "AreaChart BarChart BarChart3D LineChart LineChart3D "
+                        + "CategoryDataset/PieDataset: AreaChart BarChart BarChart3D "
+			+ "LineChart LineChart3D "
                         + "MultiplePieChart MultiplePieChart3D PieChart PieChart3D "
                         + "RingChart SpiderWebChart StackedAreaChart StackedBarChart "
-                        + "StackedBarChart3D WaterfallChart, ScatterPlot, XYLineChart, BubbleChart");
+                        + "StackedBarChart3D WaterfallChart. "
+			+ "XYDataset: ScatterPlot XYAreaChart XYBarChart XYLineChart. "
+			+ "XYZDataset: BubbleChart.");
 
         }
 

--- a/java/src/org/exist/xquery/modules/jfreechart/JFreeChartFactory.java
+++ b/java/src/org/exist/xquery/modules/jfreechart/JFreeChartFactory.java
@@ -269,6 +269,12 @@ public class JFreeChartFactory {
                         conf.getOrientation(), conf.isGenerateLegend(), conf.isGenerateTooltips(), conf.isGenerateUrls());
 		XYPlot XYPlot = (XYPlot) chart.getPlot();
 		XYPlot.setForegroundAlpha(0.65f);
+		NumberAxis domainAxis = (NumberAxis) XYPlot.getDomainAxis();
+		domainAxis.setLowerMargin(0.15);
+		domainAxis.setUpperMargin(0.15);
+		NumberAxis rangeAxis = (NumberAxis) XYPlot.getRangeAxis();
+		rangeAxis.setLowerMargin(0.15);
+		rangeAxis.setUpperMargin(0.15);
                 //setCategoryChartParameters(chart, conf);
                 break;
 
@@ -301,6 +307,13 @@ public class JFreeChartFactory {
 	if (chart.getPlot() instanceof CategoryPlot && config.isOnlyShape()) {
 	    CategoryItemRenderer renderer = new LineAndShapeRenderer(false, true);
 	    CategoryPlot plot = (CategoryPlot) chart.getPlot();
+
+	    plot.setDomainGridlinesVisible(true);
+	    plot.setRangeGridlinesVisible(true);
+	    plot.setRangeZeroBaselineVisible(false);
+	    NumberAxis rangeAxis = (NumberAxis) plot.getRangeAxis();
+	    rangeAxis.setAutoRangeIncludesZero(false);
+	    
 	    plot.setRenderer(renderer);
 	}
     }

--- a/java/src/org/exist/xquery/modules/jfreechart/JFreeChartFactory.java
+++ b/java/src/org/exist/xquery/modules/jfreechart/JFreeChartFactory.java
@@ -1,6 +1,6 @@
 /*
  *  eXist Open Source Native XML Database
- *  Copyright (C) 2009-2013 The eXist-db Project
+ *  Copyright (C) 2009-2014 The eXist-db Project
  *  http://exist-db.org
  *
  *  This program is free software; you can redistribute it and/or
@@ -35,6 +35,7 @@ import org.jfree.chart.ChartFactory;
 import org.jfree.chart.JFreeChart;
 import org.jfree.chart.axis.CategoryLabelPositions;
 import org.jfree.chart.axis.NumberAxis;
+import org.jfree.chart.axis.SymbolAxis;
 import org.jfree.chart.labels.CategoryItemLabelGenerator;
 import org.jfree.chart.labels.StandardCategoryToolTipGenerator;
 import org.jfree.chart.labels.StandardPieSectionLabelGenerator;
@@ -45,6 +46,7 @@ import org.jfree.chart.plot.SpiderWebPlot;
 import org.jfree.chart.plot.XYPlot;
 import org.jfree.chart.renderer.category.CategoryItemRenderer;
 import org.jfree.chart.renderer.category.LineAndShapeRenderer;
+import org.jfree.chart.renderer.xy.XYDotRenderer;
 import org.jfree.chart.title.LegendTitle;
 import org.jfree.chart.title.TextTitle;
 import org.jfree.data.category.CategoryDataset;
@@ -252,46 +254,38 @@ public class JFreeChartFactory {
                 break;
             case "ScatterPlot":
                 chart = ChartFactory.createScatterPlot(
-                        conf.getTitle(), conf.getCategoryAxisLabel(), conf.getValueAxisLabel(), XYDataset,
+                        conf.getTitle(), conf.getDomainAxisLabel(), conf.getRangeAxisLabel(), XYDataset,
                         conf.getOrientation(), conf.isGenerateLegend(), conf.isGenerateTooltips(), conf.isGenerateUrls());
 
-                //setCategoryChartParameters(chart, conf);
+                setPlotAndNumberAxisParameters(chart, conf);
                 break;
             case "XYAreaChart":
                 chart = ChartFactory.createXYAreaChart(
-                        conf.getTitle(), conf.getCategoryAxisLabel(), conf.getValueAxisLabel(), XYDataset,
+                        conf.getTitle(), conf.getDomainAxisLabel(), conf.getRangeAxisLabel(), XYDataset,
                         conf.getOrientation(), conf.isGenerateLegend(), conf.isGenerateTooltips(), conf.isGenerateUrls());
 
-                //setCategoryChartParameters(chart, conf);
+                setPlotAndNumberAxisParameters(chart, conf);
                 break;
             case "XYBarChart":
                 chart = ChartFactory.createXYBarChart(
-			conf.getTitle(), conf.getCategoryAxisLabel(), true,
-			conf.getValueAxisLabel(), (IntervalXYDataset) XYDataset,
+			conf.getTitle(), conf.getDomainAxisLabel(), true,
+			conf.getRangeAxisLabel(), (IntervalXYDataset) XYDataset,
                         conf.getOrientation(), conf.isGenerateLegend(), conf.isGenerateTooltips(), conf.isGenerateUrls());
 
-                //setCategoryChartParameters(chart, conf);
+                setPlotAndNumberAxisParameters(chart, conf);
                 break;
             case "XYLineChart":
                 chart = ChartFactory.createXYLineChart(
-                        conf.getTitle(), conf.getCategoryAxisLabel(), conf.getValueAxisLabel(), XYDataset,
+                        conf.getTitle(), conf.getDomainAxisLabel(), conf.getRangeAxisLabel(), XYDataset,
                         conf.getOrientation(), conf.isGenerateLegend(), conf.isGenerateTooltips(), conf.isGenerateUrls());
 
-                //setCategoryChartParameters(chart, conf);
+                setPlotAndNumberAxisParameters(chart, conf);
                 break;
             case "BubbleChart":
                 chart = ChartFactory.createBubbleChart(
-                        conf.getTitle(), conf.getCategoryAxisLabel(), conf.getValueAxisLabel(), XYZDataset,
+                        conf.getTitle(), conf.getDomainAxisLabel(), conf.getRangeAxisLabel(), XYZDataset,
                         conf.getOrientation(), conf.isGenerateLegend(), conf.isGenerateTooltips(), conf.isGenerateUrls());
-		XYPlot XYPlot = (XYPlot) chart.getPlot();
-		XYPlot.setForegroundAlpha(0.65f);
-		NumberAxis domainAxis = (NumberAxis) XYPlot.getDomainAxis();
-		domainAxis.setLowerMargin(0.15);
-		domainAxis.setUpperMargin(0.15);
-		NumberAxis rangeAxis = (NumberAxis) XYPlot.getRangeAxis();
-		rangeAxis.setLowerMargin(0.15);
-		rangeAxis.setUpperMargin(0.15);
-                //setCategoryChartParameters(chart, conf);
+                setPlotAndNumberAxisParameters(chart, conf);
                 break;
 
 
@@ -314,7 +308,7 @@ public class JFreeChartFactory {
     
     
     private static void setCategoryChartParameters(JFreeChart chart, Configuration config) throws XPathException {
-	setRenderer(chart, config);
+	setPlotAndNumberAxisParameters(chart, config);
         setCategoryRange(chart, config);
         setCategoryItemLabelGenerator(chart, config);
         setCategoryLabelPositions(chart, config);
@@ -322,20 +316,105 @@ public class JFreeChartFactory {
         setAxisColors(chart, config);
     }
     
+    private static void setPlotAndNumberAxisParameters(JFreeChart chart, Configuration config) {
+	setRenderer(chart, config);
+	if (chart.getPlot() instanceof CategoryPlot) {
+	    CategoryPlot plot = (CategoryPlot) chart.getPlot();
+	    if (config.getForegroundAlpha() != null) {
+		plot.setForegroundAlpha(config.getForegroundAlpha());
+	    }
+	    plot.setDomainGridlinesVisible(config.isDomainGridlinesVisible());
+	    plot.setRangeGridlinesVisible(config.isRangeGridlinesVisible());
+	    plot.setRangeZeroBaselineVisible(config.isRangeZeroBaselineVisible());
+
+	    NumberAxis rangeAxis = (NumberAxis) plot.getRangeAxis();
+	    rangeAxis.setAutoRangeIncludesZero(config.isRangeAutoRangeIncludesZero());
+	    if (config.isRangeIntegerTickUnits()) {
+		rangeAxis.setStandardTickUnits(NumberAxis.createIntegerTickUnits());
+	    }
+	} else if (chart.getPlot() instanceof XYPlot) {
+	    XYPlot XYPlot = (XYPlot) chart.getPlot();
+	    if (config.getForegroundAlpha() != null) {
+		XYPlot.setForegroundAlpha(config.getForegroundAlpha());
+	    }
+
+	    XYPlot.setDomainGridlinesVisible(config.isDomainGridlinesVisible());
+	    XYPlot.setRangeGridlinesVisible(config.isRangeGridlinesVisible());
+	    XYPlot.setDomainZeroBaselineVisible(config.isDomainZeroBaselineVisible());
+	    XYPlot.setRangeZeroBaselineVisible(config.isRangeZeroBaselineVisible());
+
+	    NumberAxis domainAxis = (NumberAxis) XYPlot.getDomainAxis();
+	    Double domainLowerBound = config.getDomainLowerBound();
+	    Double domainUpperBound = config.getDomainUpperBound();
+	    Double domainLowerMargin = config.getDomainLowerMargin();
+	    Double domainUpperMargin = config.getDomainUpperMargin();
+
+	    if (domainUpperBound != null) {
+		domainAxis.setUpperBound(domainUpperBound.doubleValue());
+	    }
+	    if (domainLowerBound != null) {
+		domainAxis.setLowerBound(domainLowerBound.doubleValue());
+	    }
+
+	    if (domainLowerMargin != null) {
+		domainAxis.setLowerMargin(domainLowerMargin.doubleValue());
+	    }
+	    if (domainUpperMargin != null) {
+		domainAxis.setUpperMargin(domainUpperMargin.doubleValue());
+	    }
+
+	    if (config.isDomainIntegerTickUnits()) {
+		domainAxis.setStandardTickUnits(NumberAxis.createIntegerTickUnits());
+	    }
+	    domainAxis.setAutoRangeIncludesZero(config.isDomainAutoRangeIncludesZero());
+
+	    NumberAxis rangeAxis = (NumberAxis) XYPlot.getRangeAxis();
+	    Double rangeLowerBound = config.getRangeLowerBound();
+	    Double rangeUpperBound = config.getRangeUpperBound();
+	    Double rangeLowerMargin = config.getRangeLowerMargin();
+	    Double rangeUpperMargin = config.getRangeUpperMargin();
+
+	    if (rangeUpperBound != null) {
+		XYPlot.getRangeAxis().setUpperBound(rangeUpperBound.doubleValue());
+	    }
+	    if (rangeLowerBound != null) {
+		XYPlot.getRangeAxis().setLowerBound(rangeLowerBound.doubleValue());
+	    }
+
+	    if (rangeLowerMargin != null) {
+		rangeAxis.setLowerMargin(rangeLowerMargin.doubleValue());
+	    }
+	    if (rangeUpperMargin != null) {
+		rangeAxis.setUpperMargin(rangeUpperMargin.doubleValue());
+	    }
+
+	    if (config.isRangeIntegerTickUnits()) {
+		rangeAxis.setStandardTickUnits(NumberAxis.createIntegerTickUnits());
+	    }
+	    rangeAxis.setAutoRangeIncludesZero(config.isRangeAutoRangeIncludesZero());
+	}
+    }
+
     private static void setRenderer(JFreeChart chart, Configuration config) {
 	if (chart.getPlot() instanceof CategoryPlot && config.isOnlyShape()) {
 	    CategoryItemRenderer renderer = new LineAndShapeRenderer(false, true);
 	    CategoryPlot plot = (CategoryPlot) chart.getPlot();
-
 	    plot.setDomainGridlinesVisible(true);
 	    plot.setRangeGridlinesVisible(true);
-	    plot.setRangeZeroBaselineVisible(false);
-	    NumberAxis rangeAxis = (NumberAxis) plot.getRangeAxis();
-	    rangeAxis.setAutoRangeIncludesZero(false);
-	    
 	    plot.setRenderer(renderer);
+	} else if (chart.getPlot() instanceof XYPlot && (config.getDotWidth() != 1 || config.getDotHeight() != 1)) {
+	    XYPlot XYPlot = (XYPlot) chart.getPlot();
+	    XYDotRenderer XYDotRenderer = new XYDotRenderer();
+	    if (config.getDotWidth() != 1) {
+		XYDotRenderer.setDotWidth(config.getDotWidth());
+	    }
+	    if (config.getDotHeight() != 1) {
+		XYDotRenderer.setDotHeight(config.getDotHeight());
+	    }
+	    XYPlot.setRenderer(XYDotRenderer);
 	}
     }
+
     private static void setCategoryRange(JFreeChart chart, Configuration config) {
         Double rangeLowerBound = config.getRangeLowerBound();
         Double rangeUpperBound = config.getRangeUpperBound();

--- a/java/src/org/jfree/data/xml/XYDatasetHandler.java
+++ b/java/src/org/jfree/data/xml/XYDatasetHandler.java
@@ -25,23 +25,23 @@
  * Other names may be trademarks of their respective owners.]
  *
  * ---------------------------
- * CategoryDatasetHandler.java
+ * XYDatasetHandler.java
  * ---------------------------
- * (C) Copyright 2003-2008, by Object Refinery Limited and Contributors.
+ * (C) Copyright 2014
  *
  * Original Author:  David Gilbert (for Object Refinery Limited);
- * Contributor(s):   -;
+ * Contributor(s):   Leif-Jöran Olsson;
  *
  * Changes
  * -------
- * 23-Jan-2003 : Version 1 (DG);
+ * 27-Apr-2014 : Version 1 (ljo);
  *
  */
 
 package org.jfree.data.xml;
 
 import org.jfree.data.xy.XYDataset;
-import org.jfree.data.xy.DefaultXYDataset;
+import org.jfree.data.xy.XYSeriesCollection;
 import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
 import org.xml.sax.helpers.DefaultHandler;
@@ -52,7 +52,7 @@ import org.xml.sax.helpers.DefaultHandler;
 public class XYDatasetHandler extends RootHandler implements XYZDatasetTags {
 
     /** The dataset under construction. */
-    private DefaultXYDataset dataset;
+    private XYSeriesCollection dataset;
 
     /**
      * Creates a new handler.
@@ -71,15 +71,12 @@ public class XYDatasetHandler extends RootHandler implements XYZDatasetTags {
     }
 
     /**
-     * Adds an item to the dataset.
+     * Sets a dataset.
      *
-     * @param rowKey  the row key.
-     * @param columnKey  the column key.
-     * @param value  the value.
+     * @param series the dataset.
      */
-    public void addSeries(Comparable seriesKey, double[] valuesX, double[] valuesY) {
-	double[][] values = new double[][] {valuesX, valuesY};
-        this.dataset.addSeries(seriesKey, values);
+    public void setDataset(XYSeriesCollection series) {
+        this.dataset = series;
     }
 
     /**
@@ -97,13 +94,12 @@ public class XYDatasetHandler extends RootHandler implements XYZDatasetTags {
                              String localName,
                              String qName,
                              Attributes atts) throws SAXException {
-
         DefaultHandler current = getCurrentHandler();
         if (current != this) {
             current.startElement(namespaceURI, localName, qName, atts);
         }
         else if (qName.equals(XYDATASET_TAG)) {
-            this.dataset = new DefaultXYDataset();
+            this.dataset = new XYSeriesCollection();
         }
         else if (qName.equals(XYZDatasetTags.SERIES_TAG)) {
             XYSeriesHandler subhandler = new XYSeriesHandler(this);
@@ -129,7 +125,6 @@ public class XYDatasetHandler extends RootHandler implements XYZDatasetTags {
     public void endElement(String namespaceURI,
                            String localName,
                            String qName) throws SAXException {
-
         DefaultHandler current = getCurrentHandler();
         if (current != this) {
             current.endElement(namespaceURI, localName, qName);

--- a/java/src/org/jfree/data/xml/XYDatasetHandler.java
+++ b/java/src/org/jfree/data/xml/XYDatasetHandler.java
@@ -1,0 +1,140 @@
+/* ===========================================================
+ * JFreeChart : a free chart library for the Java(tm) platform
+ * ===========================================================
+ *
+ * (C) Copyright 2000-2013, by Object Refinery Limited and Contributors.
+ *
+ * Project Info:  http://www.jfree.org/jfreechart/index.html
+ *
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ *
+ * [Oracle and Java are registered trademarks of Oracle and/or its affiliates. 
+ * Other names may be trademarks of their respective owners.]
+ *
+ * ---------------------------
+ * CategoryDatasetHandler.java
+ * ---------------------------
+ * (C) Copyright 2003-2008, by Object Refinery Limited and Contributors.
+ *
+ * Original Author:  David Gilbert (for Object Refinery Limited);
+ * Contributor(s):   -;
+ *
+ * Changes
+ * -------
+ * 23-Jan-2003 : Version 1 (DG);
+ *
+ */
+
+package org.jfree.data.xml;
+
+import org.jfree.data.xy.XYDataset;
+import org.jfree.data.xy.DefaultXYDataset;
+import org.xml.sax.Attributes;
+import org.xml.sax.SAXException;
+import org.xml.sax.helpers.DefaultHandler;
+
+/**
+ * A SAX handler for reading a {@link XYDataset} from an XML file.
+ */
+public class XYDatasetHandler extends RootHandler implements XYZDatasetTags {
+
+    /** The dataset under construction. */
+    private DefaultXYDataset dataset;
+
+    /**
+     * Creates a new handler.
+     */
+    public XYDatasetHandler() {
+        this.dataset = null;
+    }
+
+    /**
+     * Returns the dataset.
+     *
+     * @return The dataset.
+     */
+    public XYDataset getDataset() {
+        return this.dataset;
+    }
+
+    /**
+     * Adds an item to the dataset.
+     *
+     * @param rowKey  the row key.
+     * @param columnKey  the column key.
+     * @param value  the value.
+     */
+    public void addSeries(Comparable seriesKey, double[] valuesX, double[] valuesY) {
+	double[][] values = new double[][] {valuesX, valuesY};
+        this.dataset.addSeries(seriesKey, values);
+    }
+
+    /**
+     * The start of an element.
+     *
+     * @param namespaceURI  the namespace.
+     * @param localName  the element name.
+     * @param qName  the element name.
+     * @param atts  the element attributes.
+     *
+     * @throws SAXException for errors.
+     */
+    @Override
+    public void startElement(String namespaceURI,
+                             String localName,
+                             String qName,
+                             Attributes atts) throws SAXException {
+
+        DefaultHandler current = getCurrentHandler();
+        if (current != this) {
+            current.startElement(namespaceURI, localName, qName, atts);
+        }
+        else if (qName.equals(XYDATASET_TAG)) {
+            this.dataset = new DefaultXYDataset();
+        }
+        else if (qName.equals(XYZDatasetTags.SERIES_TAG)) {
+            XYSeriesHandler subhandler = new XYSeriesHandler(this);
+            getSubHandlers().push(subhandler);
+            subhandler.startElement(namespaceURI, localName, qName, atts);
+        }
+        else {
+            throw new SAXException("Element not recognised: " + qName);
+        }
+
+    }
+
+    /**
+     * The end of an element.
+     *
+     * @param namespaceURI  the namespace.
+     * @param localName  the element name.
+     * @param qName  the element name.
+     *
+     * @throws SAXException for errors.
+     */
+    @Override
+    public void endElement(String namespaceURI,
+                           String localName,
+                           String qName) throws SAXException {
+
+        DefaultHandler current = getCurrentHandler();
+        if (current != this) {
+            current.endElement(namespaceURI, localName, qName);
+        }
+
+    }
+
+}

--- a/java/src/org/jfree/data/xml/XYDatasetReader.java
+++ b/java/src/org/jfree/data/xml/XYDatasetReader.java
@@ -2,7 +2,7 @@
  * JFreeChart : a free chart library for the Java(tm) platform
  * ===========================================================
  *
- * (C) Copyright 2013,
+ * (C) Copyright 2000-2013, by Object Refinery Limited and Contributors.
  *
  * Project Info:  http://www.jfree.org/jfreechart/index.html
  *
@@ -27,14 +27,14 @@
  * ------------------
  * XYDatasetReader.java
  * ------------------
- * (C) Copyright 2014,
+ * (C) Copyright 2014
  *
  * Original Author:  David Gilbert (for Object Refinery Limited);
- * Contributor(s):   -;
+ * Contributor(s):   Leif-Jöran Olsson;
  *
  * Changes
  * -------
- * 20-Nov-2002 : Version 1 (DG);
+ * 27-Apr-2014 : Version 1 (ljo);
  *
  */
 

--- a/java/src/org/jfree/data/xml/XYDatasetReader.java
+++ b/java/src/org/jfree/data/xml/XYDatasetReader.java
@@ -1,0 +1,151 @@
+/* ===========================================================
+ * JFreeChart : a free chart library for the Java(tm) platform
+ * ===========================================================
+ *
+ * (C) Copyright 2013,
+ *
+ * Project Info:  http://www.jfree.org/jfreechart/index.html
+ *
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ *
+ * [Oracle and Java are registered trademarks of Oracle and/or its affiliates. 
+ * Other names may be trademarks of their respective owners.]
+ *
+ * ------------------
+ * XYDatasetReader.java
+ * ------------------
+ * (C) Copyright 2014,
+ *
+ * Original Author:  David Gilbert (for Object Refinery Limited);
+ * Contributor(s):   -;
+ *
+ * Changes
+ * -------
+ * 20-Nov-2002 : Version 1 (DG);
+ *
+ */
+
+package org.jfree.data.xml;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.parsers.SAXParser;
+import javax.xml.parsers.SAXParserFactory;
+
+import org.jfree.data.xy.XYDataset;
+import org.jfree.data.xy.XYZDataset;
+import org.xml.sax.SAXException;
+
+/**
+ * A utility class for reading datasets from XML.
+ */
+public class XYDatasetReader {
+
+    /**
+     * Reads a {@link XYDataset} from an XML file.
+     *
+     * @param file  the file.
+     *
+     * @return A dataset.
+     *
+     * @throws IOException if there is a problem reading the file.
+     */
+    public static XYDataset readXYDatasetFromXML(File file)
+        throws IOException {
+        InputStream in = new FileInputStream(file);
+        return readXYDatasetFromXML(in);
+    }
+
+    /**
+     * Reads a {@link XYDataset} from a stream.
+     *
+     * @param in  the input stream.
+     *
+     * @return A dataset.
+     *
+     * @throws IOException if there is an I/O error.
+     */
+    public static XYDataset readXYDatasetFromXML(InputStream in)
+        throws IOException {
+
+        XYDataset result = null;
+        SAXParserFactory factory = SAXParserFactory.newInstance();
+        try {
+            SAXParser parser = factory.newSAXParser();
+            XYDatasetHandler handler = new XYDatasetHandler();
+            parser.parse(in, handler);
+            result = handler.getDataset();
+        }
+        catch (SAXException e) {
+            System.out.println(e.getMessage());
+        }
+        catch (ParserConfigurationException e2) {
+            System.out.println(e2.getMessage());
+        }
+        return result;
+
+    }
+
+    /**
+     * Reads a {@link XYZDataset} from a file.
+     *
+     * @param file  the file.
+     *
+     * @return A dataset.
+     *
+     * @throws IOException if there is a problem reading the file.
+     */
+    public static XYZDataset readXYZDatasetFromXML(File file)
+        throws IOException {
+        InputStream in = new FileInputStream(file);
+        return readXYZDatasetFromXML(in);
+    }
+
+    /**
+     * Reads a {@link XYZDataset} from a stream.
+     *
+     * @param in  the stream.
+     *
+     * @return A dataset.
+     *
+     * @throws IOException if there is a problem reading the file.
+     */
+    public static XYZDataset readXYZDatasetFromXML(InputStream in)
+        throws IOException {
+
+        XYZDataset result = null;
+
+        SAXParserFactory factory = SAXParserFactory.newInstance();
+        try {
+            SAXParser parser = factory.newSAXParser();
+            XYZDatasetHandler handler = new XYZDatasetHandler();
+            parser.parse(in, handler);
+            result = handler.getDataset();
+        }
+        catch (SAXException e) {
+            System.out.println(e.getMessage());
+        }
+        catch (ParserConfigurationException e2) {
+            System.out.println(e2.getMessage());
+        }
+        return result;
+
+    }
+}

--- a/java/src/org/jfree/data/xml/XYSeriesHandler.java
+++ b/java/src/org/jfree/data/xml/XYSeriesHandler.java
@@ -1,0 +1,151 @@
+/* ===========================================================
+ * JFreeChart : a free chart library for the Java(tm) platform
+ * ===========================================================
+ *
+ * (C) Copyright 2000-2013, by Object Refinery Limited and Contributors.
+ *
+ * Project Info:  http://www.jfree.org/jfreechart/index.html
+ *
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ *
+ * [Oracle and Java are registered trademarks of Oracle and/or its affiliates. 
+ * Other names may be trademarks of their respective owners.]
+ *
+ * --------------------------
+ * XYSeriesHandler.java
+ * --------------------------
+ * (C) Copyright 2014
+ *
+ * Original Author:  David Gilbert (for Object Refinery Limited);
+ * Contributor(s):   -;
+ *
+ * Changes
+ * -------
+ * 23-Jan-2003 : Version 1 (DG);
+ *
+ */
+
+package org.jfree.data.xml;
+
+import java.util.Iterator;
+import java.util.ArrayList;
+
+import org.jfree.data.xy.DefaultXYDataset;
+import org.jfree.data.xy.XYDataItem;
+import org.jfree.data.xy.XYSeries;
+import org.xml.sax.Attributes;
+import org.xml.sax.SAXException;
+import org.xml.sax.helpers.DefaultHandler;
+
+/**
+ * A handler for reading a series for a XY dataset.
+ */
+public class XYSeriesHandler extends DefaultHandler
+        implements XYZDatasetTags {
+
+    /** The root handler. */
+    private RootHandler root;
+
+    /** The series key. */
+    private Comparable seriesKey;
+
+    /** The values. */
+    private XYSeries values;
+
+    /**
+     * Creates a new item handler.
+     *
+     * @param root  the root handler.
+     */
+    public XYSeriesHandler(RootHandler root) {
+        this.root = root;
+        this.values = new XYSeries(this.seriesKey);
+    }
+
+    /**
+     * Sets the series key.
+     *
+     * @param key  the key.
+     */
+    public void setSeriesKey(Comparable key) {
+        this.seriesKey = key;
+    }
+
+    /**
+     * Adds an XY item to the temporary storage for the series.
+     *
+     * @param valueX  the X value.
+     * @param valueY  the Y value.
+     */
+    public void addItem(double valueX, double valueY) {
+        this.values.add(valueX, valueY);
+    }
+
+    /**
+     * The start of an element.
+     *
+     * @param namespaceURI  the namespace.
+     * @param localName  the element name.
+     * @param qName  the element name.
+     * @param atts  the attributes.
+     *
+     * @throws SAXException for errors.
+     */
+    @Override
+    public void startElement(String namespaceURI,
+                             String localName,
+                             String qName,
+                             Attributes atts) throws SAXException {
+
+        if (qName.equals(SERIES_TAG)) {
+            setSeriesKey(atts.getValue("name"));
+            XYZItemHandler subhandler = new XYZItemHandler(this.root, this);
+            this.root.pushSubHandler(subhandler);
+        }
+        else if (qName.equals(ITEM_TAG)) {
+            XYZItemHandler subhandler = new XYZItemHandler(this.root, this);
+            this.root.pushSubHandler(subhandler);
+            subhandler.startElement(namespaceURI, localName, qName, atts);
+        }
+
+        else {
+            throw new SAXException(
+                "Expecting <Series> or <Item> tag...found " + qName
+            );
+        }
+    }
+
+    /**
+     * The end of an element.
+     *
+     * @param namespaceURI  the namespace.
+     * @param localName  the element name.
+     * @param qName  the element name.
+     */
+    @Override
+    public void endElement(String namespaceURI,
+                           String localName,
+                           String qName) {
+
+        if (this.root instanceof XYDatasetHandler) {
+            XYDatasetHandler handler = (XYDatasetHandler) this.root;
+	    handler.addSeries(this.seriesKey, values.toArray()[0], values.toArray()[1]);
+            this.root.popSubHandler();
+        }
+
+    }
+
+}

--- a/java/src/org/jfree/data/xml/XYSeriesHandler.java
+++ b/java/src/org/jfree/data/xml/XYSeriesHandler.java
@@ -30,11 +30,11 @@
  * (C) Copyright 2014
  *
  * Original Author:  David Gilbert (for Object Refinery Limited);
- * Contributor(s):   -;
+ * Contributor(s):   Leif-Jöran Olsson;
  *
  * Changes
  * -------
- * 23-Jan-2003 : Version 1 (DG);
+ * 27-Apr-2014 : Version 1 (ljo);
  *
  */
 
@@ -46,6 +46,7 @@ import java.util.ArrayList;
 import org.jfree.data.xy.DefaultXYDataset;
 import org.jfree.data.xy.XYDataItem;
 import org.jfree.data.xy.XYSeries;
+import org.jfree.data.xy.XYSeriesCollection;
 import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
 import org.xml.sax.helpers.DefaultHandler;
@@ -63,7 +64,7 @@ public class XYSeriesHandler extends DefaultHandler
     private Comparable seriesKey;
 
     /** The values. */
-    private XYSeries values;
+    private XYSeriesCollection values;
 
     /**
      * Creates a new item handler.
@@ -72,7 +73,7 @@ public class XYSeriesHandler extends DefaultHandler
      */
     public XYSeriesHandler(RootHandler root) {
         this.root = root;
-        this.values = new XYSeries(this.seriesKey);
+        this.values = new XYSeriesCollection();
     }
 
     /**
@@ -82,6 +83,11 @@ public class XYSeriesHandler extends DefaultHandler
      */
     public void setSeriesKey(Comparable key) {
         this.seriesKey = key;
+	this.values.addSeries(new XYSeries(this.seriesKey));
+    }
+
+    public int getSeriesCount() {
+	return this.values.getSeriesCount(); 
     }
 
     /**
@@ -91,7 +97,8 @@ public class XYSeriesHandler extends DefaultHandler
      * @param valueY  the Y value.
      */
     public void addItem(double valueX, double valueY) {
-        this.values.add(valueX, valueY);
+	int series = getSeriesCount() - 1;
+        this.values.getSeries(series).add(valueX, valueY);
     }
 
     /**
@@ -109,7 +116,6 @@ public class XYSeriesHandler extends DefaultHandler
                              String localName,
                              String qName,
                              Attributes atts) throws SAXException {
-
         if (qName.equals(SERIES_TAG)) {
             setSeriesKey(atts.getValue("name"));
             XYZItemHandler subhandler = new XYZItemHandler(this.root, this);
@@ -139,10 +145,9 @@ public class XYSeriesHandler extends DefaultHandler
     public void endElement(String namespaceURI,
                            String localName,
                            String qName) {
-
         if (this.root instanceof XYDatasetHandler) {
             XYDatasetHandler handler = (XYDatasetHandler) this.root;
-	    handler.addSeries(this.seriesKey, values.toArray()[0], values.toArray()[1]);
+	    handler.setDataset(values);
             this.root.popSubHandler();
         }
 

--- a/java/src/org/jfree/data/xml/XYZDatasetHandler.java
+++ b/java/src/org/jfree/data/xml/XYZDatasetHandler.java
@@ -27,14 +27,14 @@
  * ---------------------------
  * XYZDatasetHandler.java
  * ---------------------------
- * (C) Copyright 2014, 
+ * (C) Copyright 2014 
  *
  * Original Author:  David Gilbert (for Object Refinery Limited);
- * Contributor(s):   -;
+ * Contributor(s):   Leif-Jöran Olsson;
  *
  * Changes
  * -------
- * 23-Jan-2003 : Version 1 (DG);
+ * 27-Apr-2014 : Version 1 (ljo);
  *
  */
 

--- a/java/src/org/jfree/data/xml/XYZDatasetHandler.java
+++ b/java/src/org/jfree/data/xml/XYZDatasetHandler.java
@@ -1,0 +1,140 @@
+/* ===========================================================
+ * JFreeChart : a free chart library for the Java(tm) platform
+ * ===========================================================
+ *
+ * (C) Copyright 2000-2013, by Object Refinery Limited and Contributors.
+ *
+ * Project Info:  http://www.jfree.org/jfreechart/index.html
+ *
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ *
+ * [Oracle and Java are registered trademarks of Oracle and/or its affiliates. 
+ * Other names may be trademarks of their respective owners.]
+ *
+ * ---------------------------
+ * XYZDatasetHandler.java
+ * ---------------------------
+ * (C) Copyright 2014, 
+ *
+ * Original Author:  David Gilbert (for Object Refinery Limited);
+ * Contributor(s):   -;
+ *
+ * Changes
+ * -------
+ * 23-Jan-2003 : Version 1 (DG);
+ *
+ */
+
+package org.jfree.data.xml;
+
+import org.jfree.data.xy.XYZDataset;
+import org.jfree.data.xy.DefaultXYZDataset;
+import org.xml.sax.Attributes;
+import org.xml.sax.SAXException;
+import org.xml.sax.helpers.DefaultHandler;
+
+/**
+ * A SAX handler for reading a {@link XYZDataset} from an XML file.
+ */
+public class XYZDatasetHandler extends RootHandler implements XYZDatasetTags {
+
+    /** The dataset under construction. */
+    private DefaultXYZDataset dataset;
+
+    /**
+     * Creates a new handler.
+     */
+    public XYZDatasetHandler() {
+        this.dataset = null;
+    }
+
+    /**
+     * Returns the dataset.
+     *
+     * @return The dataset.
+     */
+    public XYZDataset getDataset() {
+        return this.dataset;
+    }
+
+    /**
+     * Adds an item to the dataset.
+     *
+     * @param rowKey  the row key.
+     * @param columnKey  the column key.
+     * @param value  the value.
+     */
+    public void addSeries(Comparable seriesKey, double[] valuesX, double[] valuesY, double[] valuesZ) {
+	double[][] values = new double[][] {valuesX, valuesY, valuesZ};
+        this.dataset.addSeries(seriesKey, values);
+    }
+
+    /**
+     * The start of an element.
+     *
+     * @param namespaceURI  the namespace.
+     * @param localName  the element name.
+     * @param qName  the element name.
+     * @param atts  the element attributes.
+     *
+     * @throws SAXException for errors.
+     */
+    @Override
+    public void startElement(String namespaceURI,
+                             String localName,
+                             String qName,
+                             Attributes atts) throws SAXException {
+
+        DefaultHandler current = getCurrentHandler();
+        if (current != this) {
+            current.startElement(namespaceURI, localName, qName, atts);
+        }
+        else if (qName.equals(XYZDatasetTags.XYZDATASET_TAG)) {
+            this.dataset = new DefaultXYZDataset();
+        }
+        else if (qName.equals(XYZDatasetTags.SERIES_TAG)) {
+            XYZSeriesHandler subhandler = new XYZSeriesHandler(this);
+            getSubHandlers().push(subhandler);
+            subhandler.startElement(namespaceURI, localName, qName, atts);
+        }
+        else {
+            throw new SAXException("Element not recognised: " + qName);
+        }
+
+    }
+
+    /**
+     * The end of an element.
+     *
+     * @param namespaceURI  the namespace.
+     * @param localName  the element name.
+     * @param qName  the element name.
+     *
+     * @throws SAXException for errors.
+     */
+    @Override
+    public void endElement(String namespaceURI,
+                           String localName,
+                           String qName) throws SAXException {
+
+        DefaultHandler current = getCurrentHandler();
+        if (current != this) {
+            current.endElement(namespaceURI, localName, qName);
+        }
+
+    }
+
+}

--- a/java/src/org/jfree/data/xml/XYZDatasetTags.java
+++ b/java/src/org/jfree/data/xml/XYZDatasetTags.java
@@ -27,14 +27,14 @@
  * ----------------
  * XYZDatasetTags.java
  * ----------------
- * (C) Copyright 2014,
+ * (C) Copyright 2014
  *
  * Original Author:  David Gilbert (for Object Refinery Limited);
- * Contributor(s):   -;
+ * Contributor(s):   Leif-Jöran Olsson;
  *
  * Changes
  * -------
- * 23-Jan-2003 : Version 1 (DG);
+ * 27-Apr-2014 : Version 1 (ljo);
  *
  */
 

--- a/java/src/org/jfree/data/xml/XYZDatasetTags.java
+++ b/java/src/org/jfree/data/xml/XYZDatasetTags.java
@@ -1,0 +1,81 @@
+/* ===========================================================
+ * JFreeChart : a free chart library for the Java(tm) platform
+ * ===========================================================
+ *
+ * (C) Copyright 2000-2013, by Object Refinery Limited and Contributors.
+ *
+ * Project Info:  http://www.jfree.org/jfreechart/index.html
+ *
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ *
+ * [Oracle and Java are registered trademarks of Oracle and/or its affiliates. 
+ * Other names may be trademarks of their respective owners.]
+ *
+ * ----------------
+ * XYZDatasetTags.java
+ * ----------------
+ * (C) Copyright 2014,
+ *
+ * Original Author:  David Gilbert (for Object Refinery Limited);
+ * Contributor(s):   -;
+ *
+ * Changes
+ * -------
+ * 23-Jan-2003 : Version 1 (DG);
+ *
+ */
+
+package org.jfree.data.xml;
+
+/**
+ * Constants for the tags that identify the elements in the XML files.
+ */
+public interface XYZDatasetTags {
+
+    /** The 'PieDataset' element name. */
+    public static final String PIEDATASET_TAG = "PieDataset";
+
+    /** The 'CategoryDataset' element name. */
+    public static final String CATEGORYDATASET_TAG = "CategoryDataset";
+
+    /** The 'XYDataset' element name. */
+    public static final String XYDATASET_TAG = "XYDataset";
+
+    /** The 'XYZDataset' element name. */
+    public static final String XYZDATASET_TAG = "XYZDataset";
+
+    /** The 'Series' element name. */
+    public static final String SERIES_TAG = "Series";
+
+    /** The 'Item' element name. */
+    public static final String ITEM_TAG = "Item";
+
+    /** The 'Key' element name. */
+    public static final String KEY_TAG = "Key";
+
+    /** The 'Value' element name. */
+    public static final String VALUE_TAG = "Value";
+
+    /** The 'X' element name. */
+    public static final String X_VALUE_TAG = "X";
+
+    /** The 'Y' element name. */
+    public static final String Y_VALUE_TAG = "Y";
+
+    /** The 'Z' element name. */
+    public static final String Z_VALUE_TAG = "Z";
+
+}

--- a/java/src/org/jfree/data/xml/XYZItemHandler.java
+++ b/java/src/org/jfree/data/xml/XYZItemHandler.java
@@ -27,14 +27,14 @@
  * ----------------
  * XYZItemHandler.java
  * ----------------
- * (C) Copyright 2014, 
+ * (C) Copyright 2014
  *
  * Original Author:  David Gilbert (for Object Refinery Limited);
- * Contributor(s):   -;
+ * Contributor(s):   Leif-Jöran Olsson;
  *
  * Changes
  * -------
- * 23-Jan-2003 : Version 1 (DG);
+ * 27-Apr-2014 : Version 1 (ljo);
  *
  */
 
@@ -111,9 +111,11 @@ public class XYZItemHandler extends DefaultHandler implements XYZDatasetTags {
 	if (this.parent instanceof XYSeriesHandler) {
             XYSeriesHandler handler = (XYSeriesHandler) this.parent;
             handler.addItem((double) this.valueX, (double) this.valueY);
+	    System.out.println("addSeriesItem: X: " + this.valueX + " Y: " + this.valueY);
 	} else if (this.parent instanceof XYZSeriesHandler) {
 	    XYZSeriesHandler handler = (XYZSeriesHandler) this.parent;
 	    handler.addItem((double) this.valueX, (double) this.valueY, (double) this.valueZ);
+	    System.out.println("addSeriesItem: X: " + this.valueX + " Y: " + this.valueY + " Z: " + this.valueZ);
 	}
     }
 

--- a/java/src/org/jfree/data/xml/XYZItemHandler.java
+++ b/java/src/org/jfree/data/xml/XYZItemHandler.java
@@ -111,11 +111,11 @@ public class XYZItemHandler extends DefaultHandler implements XYZDatasetTags {
 	if (this.parent instanceof XYSeriesHandler) {
             XYSeriesHandler handler = (XYSeriesHandler) this.parent;
             handler.addItem((double) this.valueX, (double) this.valueY);
-	    System.out.println("addSeriesItem: X: " + this.valueX + " Y: " + this.valueY);
+	    //System.out.println("addSeriesItem: X: " + this.valueX + " Y: " + this.valueY);
 	} else if (this.parent instanceof XYZSeriesHandler) {
 	    XYZSeriesHandler handler = (XYZSeriesHandler) this.parent;
 	    handler.addItem((double) this.valueX, (double) this.valueY, (double) this.valueZ);
-	    System.out.println("addSeriesItem: X: " + this.valueX + " Y: " + this.valueY + " Z: " + this.valueZ);
+	    //System.out.println("addSeriesItem: X: " + this.valueX + " Y: " + this.valueY + " Z: " + this.valueZ);
 	}
     }
 

--- a/java/src/org/jfree/data/xml/XYZItemHandler.java
+++ b/java/src/org/jfree/data/xml/XYZItemHandler.java
@@ -1,0 +1,174 @@
+/* ===========================================================
+ * JFreeChart : a free chart library for the Java(tm) platform
+ * ===========================================================
+ *
+ * (C) Copyright 2014,
+ *
+ * Project Info:  http://www.jfree.org/jfreechart/index.html
+ *
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ *
+ * [Oracle and Java are registered trademarks of Oracle and/or its affiliates. 
+ * Other names may be trademarks of their respective owners.]
+ *
+ * ----------------
+ * XYZItemHandler.java
+ * ----------------
+ * (C) Copyright 2014, 
+ *
+ * Original Author:  David Gilbert (for Object Refinery Limited);
+ * Contributor(s):   -;
+ *
+ * Changes
+ * -------
+ * 23-Jan-2003 : Version 1 (DG);
+ *
+ */
+
+package org.jfree.data.xml;
+
+import org.xml.sax.Attributes;
+import org.xml.sax.SAXException;
+import org.xml.sax.helpers.DefaultHandler;
+
+/**
+ * A handler for reading XYZ items.
+ */
+public class XYZItemHandler extends DefaultHandler implements XYZDatasetTags {
+
+    /** The root handler. */
+    private RootHandler root;
+
+    /** The parent handler (can be the same as root, but not always). */
+    private DefaultHandler parent;
+
+    /** The valueX. */
+    private Number valueX;
+
+    /** The valueY. */
+    private Number valueY;
+
+    /** The valueZ. */
+    private Number valueZ;
+
+    /**
+     * Creates a new item handler.
+     *
+     * @param root  the root handler.
+     * @param parent  the parent handler.
+     */
+    public XYZItemHandler(RootHandler root, DefaultHandler parent) {
+        this.root = root;
+        this.parent = parent;
+        this.valueX = null;
+        this.valueY = null;
+        this.valueZ = null;
+    }
+
+    /**
+     * Returns the X value that has been read by the handler, or <code>null</code>.
+     *
+     * @return The valueX.
+     */
+    public Number getXValue() {
+        return this.valueX;
+    }
+
+    public Number getYValue() {
+        return this.valueY;
+    }
+
+    public Number getZValue() {
+        return this.valueZ;
+    }
+
+    public void setXValue(Number valueX) {
+        this.valueX = valueX;
+    }
+
+    public void setYValue(Number valueY) {
+        this.valueY = valueY;
+    }
+
+    public void setZValue(Number valueZ) {
+        this.valueZ = valueZ;
+    }
+
+    public void addSeriesItem() {
+	if (this.parent instanceof XYSeriesHandler) {
+            XYSeriesHandler handler = (XYSeriesHandler) this.parent;
+            handler.addItem((double) this.valueX, (double) this.valueY);
+	} else if (this.parent instanceof XYZSeriesHandler) {
+	    XYZSeriesHandler handler = (XYZSeriesHandler) this.parent;
+	    handler.addItem((double) this.valueX, (double) this.valueY, (double) this.valueZ);
+	}
+    }
+
+    /**
+     * The start of an element.
+     *
+     * @param namespaceURI  the namespace.
+     * @param localName  the element name.
+     * @param qName  the element name.
+     * @param atts  the attributes.
+     *
+     * @throws SAXException for errors.
+     */
+    @Override
+    public void startElement(String namespaceURI,
+                             String localName,
+                             String qName,
+                             Attributes atts) throws SAXException {
+	if (qName.equals(ITEM_TAG) || qName.equals(X_VALUE_TAG) || qName.equals(Y_VALUE_TAG) || qName.equals(Z_VALUE_TAG)) {
+            XYZValueHandler subhandler = new XYZValueHandler(this.root, this);
+            this.root.pushSubHandler(subhandler);
+        }
+        else {
+            throw new SAXException(
+                "Expected <Item>, <X>, <Y>, or <Z>...found " + qName
+            );
+        }
+
+    }
+
+    /**
+     * The end of an element.
+     *
+     * @param namespaceURI  the namespace.
+     * @param localName  the element name.
+     * @param qName  the element name.
+     */
+    @Override
+    public void endElement(String namespaceURI,
+                           String localName,
+                           String qName) {
+	//if (this.parent instanceof XYDatasetHandler) {
+        //    XYDatasetHandler handler = (XYDatasetHandler) this.parent;
+        //    handler.addItem(this.valueX, this.valueY);
+        //    this.root.popSubHandler();
+        //}
+	//else if (this.parent instanceof XYZDatasetHandler) {
+        //    XYZDatasetHandler handler = (XYZDatasetHandler) this.parent;
+        //    handler.addItem(this.valueX, this.valueY, this.valueZ);
+        //    this.root.popSubHandler();
+        //}
+        //else
+	if (this.parent instanceof XYSeriesHandler || this.parent instanceof XYZSeriesHandler) {
+	    addSeriesItem();
+            this.root.popSubHandler();
+        }
+    }
+}

--- a/java/src/org/jfree/data/xml/XYZSeriesHandler.java
+++ b/java/src/org/jfree/data/xml/XYZSeriesHandler.java
@@ -1,0 +1,186 @@
+/* ===========================================================
+ * JFreeChart : a free chart library for the Java(tm) platform
+ * ===========================================================
+ *
+ * (C) Copyright 2000-2013, by Object Refinery Limited and Contributors.
+ *
+ * Project Info:  http://www.jfree.org/jfreechart/index.html
+ *
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ *
+ * [Oracle and Java are registered trademarks of Oracle and/or its affiliates. 
+ * Other names may be trademarks of their respective owners.]
+ *
+ * --------------------------
+ * XYZSeriesHandler.java
+ * --------------------------
+ * (C) Copyright 2014
+ *
+ * Original Author:  David Gilbert (for Object Refinery Limited);
+ * Contributor(s):   -;
+ *
+ * Changes
+ * -------
+ * 23-Jan-2003 : Version 1 (DG);
+ *
+ */
+
+package org.jfree.data.xml;
+
+import java.util.ArrayList;
+
+import org.xml.sax.Attributes;
+import org.xml.sax.SAXException;
+import org.xml.sax.helpers.DefaultHandler;
+
+/**
+ * A handler for reading a series for a XYZ dataset.
+ */
+public class XYZSeriesHandler extends DefaultHandler
+        implements XYZDatasetTags {
+
+    /** The root handler. */
+    private RootHandler root;
+
+    /** The series key. */
+    private ArrayList<Comparable> seriesKeys;
+
+    /** The values. */
+    private ArrayList<ArrayList<Double>> valuesX;
+    private ArrayList<ArrayList<Double>> valuesY;
+    private ArrayList<ArrayList<Double>> valuesZ;
+
+    /**
+     * Creates a new item handler.
+     *
+     * @param root  the root handler.
+     */
+    public XYZSeriesHandler(RootHandler root) {
+        this.root = root;
+	this.seriesKeys = new ArrayList<Comparable>();
+	this.valuesX = new ArrayList<ArrayList<Double>>();
+	this.valuesY = new ArrayList<ArrayList<Double>>();
+	this.valuesZ = new ArrayList<ArrayList<Double>>();
+    }
+
+    /**
+     * Sets the series key.
+     *
+     * @param key  the key.
+     */
+    public void setSeriesKey(Comparable key) {
+        this.seriesKeys.add(key);
+	this.valuesX.add(new ArrayList<Double>());
+	this.valuesY.add(new ArrayList<Double>());
+	this.valuesZ.add(new ArrayList<Double>());
+    }
+
+
+    /**
+     * Gets the series key.
+     *
+     */
+    public Comparable getSeriesKey(final int i) {
+	if (i > getSeriesCount()) {
+	    return "n/a";
+	} else { 
+	    return this.seriesKeys.get(i);
+	}
+    }
+
+    public int getSeriesCount() {
+	return this.seriesKeys.size(); 
+    }
+
+    /**
+     * Adds an item to the temporary storage for the series.
+     *
+     * @param key  the key.
+     * @param value  the value.
+     */
+    public void addItem(final double valueX, final double valueY, final double valueZ) {
+	int series = getSeriesCount() - 1;
+        this.valuesX.get(series).add(new Double(valueX));
+        this.valuesY.get(series).add(new Double(valueY));
+        this.valuesZ.get(series).add(new Double(valueZ));
+    }
+
+    /**
+     * The start of an element.
+     *
+     * @param namespaceURI  the namespace.
+     * @param localName  the element name.
+     * @param qName  the element name.
+     * @param atts  the attributes.
+     *
+     * @throws SAXException for errors.
+     */
+    @Override
+    public void startElement(String namespaceURI,
+                             String localName,
+                             String qName,
+                             Attributes atts) throws SAXException {
+        if (qName.equals(SERIES_TAG)) {
+            setSeriesKey(atts.getValue("name"));
+            XYZItemHandler subhandler = new XYZItemHandler(this.root, this);
+            this.root.pushSubHandler(subhandler);
+        }
+        else if (qName.equals(ITEM_TAG)) {
+            XYZItemHandler subhandler = new XYZItemHandler(this.root, this);
+            this.root.pushSubHandler(subhandler);
+            subhandler.startElement(namespaceURI, localName, qName, atts);
+        }
+
+        else {
+            throw new SAXException(
+                "Expecting <Series> or <Item> tag...found " + qName
+            );
+        }
+    }
+
+    /**
+     * The end of an element.
+     *
+     * @param namespaceURI  the namespace.
+     * @param localName  the element name.
+     * @param qName  the element name.
+     */
+    @Override
+    public void endElement(String namespaceURI,
+                           String localName,
+                           String qName) {
+
+        if (this.root instanceof XYZDatasetHandler) {
+            XYZDatasetHandler handler = (XYZDatasetHandler) this.root;
+	    int seriesCount = getSeriesCount();
+	    int itemCount = this.valuesX.get(0).size();
+	    for (int series = 0; series < seriesCount; series++) {
+		double[] valuesX = new double[itemCount];
+		double[] valuesY = new double[itemCount];
+		double[] valuesZ = new double[itemCount];
+		for (int key = 0; key < itemCount; key++) {
+		    valuesX[key] = this.valuesX.get(series).get(key).doubleValue();
+		    valuesY[key] = this.valuesY.get(series).get(key).doubleValue();
+		    valuesZ[key] = this.valuesZ.get(series).get(key).doubleValue();
+		    //System.out.println("XYZSeriesHandler::values: " + getSeriesKey(series) + ":" + this.valuesX.get(series).get(key) + ":" + this.valuesY.get(series).get(key) + ":" + this.valuesZ.get(series).get(key));
+		}
+		handler.addSeries(getSeriesKey(series), valuesX, valuesY, valuesZ);
+	    }
+            this.root.popSubHandler();
+        }
+
+    }
+}

--- a/java/src/org/jfree/data/xml/XYZSeriesHandler.java
+++ b/java/src/org/jfree/data/xml/XYZSeriesHandler.java
@@ -30,11 +30,11 @@
  * (C) Copyright 2014
  *
  * Original Author:  David Gilbert (for Object Refinery Limited);
- * Contributor(s):   -;
+ * Contributor(s):   Leif-Jöran Olsson;
  *
  * Changes
  * -------
- * 23-Jan-2003 : Version 1 (DG);
+ * 27-Apr-2014 : Version 1 (ljo);
  *
  */
 
@@ -109,7 +109,9 @@ public class XYZSeriesHandler extends DefaultHandler
      * Adds an item to the temporary storage for the series.
      *
      * @param key  the key.
-     * @param value  the value.
+     * @param valueX  the X value.
+     * @param valueY  the Y value.
+     * @param valueZ  the Z value.
      */
     public void addItem(final double valueX, final double valueY, final double valueZ) {
 	int series = getSeriesCount() - 1;

--- a/java/src/org/jfree/data/xml/XYZValueHandler.java
+++ b/java/src/org/jfree/data/xml/XYZValueHandler.java
@@ -27,15 +27,14 @@
  * -----------------
  * XYZValueHandler.java
  * -----------------
- * (C) Copyright 2014,
+ * (C) Copyright 2014
  *
  * Original Author:  David Gilbert (for Object Refinery Limited);
- * Contributor(s):   Luke Quinane;
+ * Contributor(s):   Leif-Jöran Olsson;
  *
  * Changes
  * -------
- * 23-Jan-2003 : Version 1 (DG);
- * 25-Nov-2003 : Patch to handle 'NaN' values (DG);
+ * 27-Apr-2014 : Version 1 (ljo);
  *
  */
 
@@ -46,7 +45,7 @@ import org.xml.sax.SAXException;
 import org.xml.sax.helpers.DefaultHandler;
 
 /**
- * A handler for reading a 'XYZValue' element.
+ * A handler for reading a 'XYZValue' or 'XYValue' element.
  */
 public class XYZValueHandler extends DefaultHandler implements XYZDatasetTags {
 
@@ -118,17 +117,17 @@ public class XYZValueHandler extends DefaultHandler implements XYZDatasetTags {
 	} catch (NumberFormatException e1) {
 	    value = null;
 	}
-	if ((qName.equals(Z_VALUE_TAG) && rootHandler instanceof XYZDatasetHandler) || (qName.equals(Y_VALUE_TAG) && rootHandler instanceof XYDatasetHandler)) {
-	    if (qName.equals(Z_VALUE_TAG) && rootHandler instanceof XYZDatasetHandler) {
+	if ((qName.equals(Z_VALUE_TAG) && rootHandler instanceof XYZDatasetHandler) 
+	    || (qName.equals(Y_VALUE_TAG) && rootHandler instanceof XYDatasetHandler)) {
+	    if (qName.equals(Z_VALUE_TAG)) {
 		this.itemHandler.setZValue(value);
-	    } else if (qName.equals(Y_VALUE_TAG) && rootHandler instanceof XYZDatasetHandler) {
+	    } else if (qName.equals(Y_VALUE_TAG)) {
 		this.itemHandler.setYValue(value);
 	    }
-
-            this.rootHandler.popSubHandler();
-            this.rootHandler.pushSubHandler(
-                new XYZValueHandler(this.rootHandler, this.itemHandler)
-            );
+            //this.rootHandler.popSubHandler();
+            //this.rootHandler.pushSubHandler(
+            //    new XYZValueHandler(this.rootHandler, this.itemHandler)
+            //);
 	} else if (qName.equals(X_VALUE_TAG) || (qName.equals(Y_VALUE_TAG) && rootHandler instanceof XYZDatasetHandler)) {
 	    if (qName.equals(X_VALUE_TAG)) {
 		this.itemHandler.setXValue(value);

--- a/java/src/org/jfree/data/xml/XYZValueHandler.java
+++ b/java/src/org/jfree/data/xml/XYZValueHandler.java
@@ -1,0 +1,179 @@
+/* ===========================================================
+ * JFreeChart : a free chart library for the Java(tm) platform
+ * ===========================================================
+ *
+ * (C) Copyright 2000-2013, by Object Refinery Limited and Contributors.
+ *
+ * Project Info:  http://www.jfree.org/jfreechart/index.html
+ *
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ *
+ * [Oracle and Java are registered trademarks of Oracle and/or its affiliates. 
+ * Other names may be trademarks of their respective owners.]
+ *
+ * -----------------
+ * XYZValueHandler.java
+ * -----------------
+ * (C) Copyright 2014,
+ *
+ * Original Author:  David Gilbert (for Object Refinery Limited);
+ * Contributor(s):   Luke Quinane;
+ *
+ * Changes
+ * -------
+ * 23-Jan-2003 : Version 1 (DG);
+ * 25-Nov-2003 : Patch to handle 'NaN' values (DG);
+ *
+ */
+
+package org.jfree.data.xml;
+
+import org.xml.sax.Attributes;
+import org.xml.sax.SAXException;
+import org.xml.sax.helpers.DefaultHandler;
+
+/**
+ * A handler for reading a 'XYZValue' element.
+ */
+public class XYZValueHandler extends DefaultHandler implements XYZDatasetTags {
+
+    /** The root handler. */
+    private RootHandler rootHandler;
+
+    /** The item handler. */
+    private XYZItemHandler itemHandler;
+
+    /** Storage for the current CDATA */
+    private StringBuffer currentText;
+
+    /**
+     * Creates a new XYZ value handler.
+     *
+     * @param rootHandler  the root handler.
+     * @param itemHandler  the item handler.
+     */
+    public XYZValueHandler(RootHandler rootHandler, XYZItemHandler itemHandler) {
+        this.rootHandler = rootHandler;
+        this.itemHandler = itemHandler;
+        this.currentText = new StringBuffer();
+    }
+
+    /**
+     * The start of an element.
+     *
+     * @param namespaceURI  the namespace.
+     * @param localName  the element name.
+     * @param qName  the element name.
+     * @param atts  the attributes.
+     *
+     * @throws SAXException for errors.
+     */
+    @Override
+    public void startElement(String namespaceURI,
+                             String localName,
+                             String qName,
+                             Attributes atts) throws SAXException {
+        if (qName.equals(ITEM_TAG) || qName.equals(X_VALUE_TAG) || qName.equals(Y_VALUE_TAG) || qName.equals(Z_VALUE_TAG)) {
+            // no attributes to read
+            clearCurrentText();
+        }
+        else {
+            throw new SAXException("Expecting <Item>, <X>, <Y>, or <Z> but found " + qName);
+        }
+
+    }
+
+    /**
+     * The end of an element.
+     *
+     * @param namespaceURI  the namespace.
+     * @param localName  the element name.
+     * @param qName  the element name.
+     *
+     * @throws SAXException for errors.
+     */
+    @Override
+    public void endElement(String namespaceURI,
+                           String localName,
+                           String qName) throws SAXException {
+	Number value;
+	try {
+	    value = Double.valueOf(getCurrentText());
+	    if (((Double) value).isNaN()) {
+		value = null;
+	    }
+	} catch (NumberFormatException e1) {
+	    value = null;
+	}
+	if ((qName.equals(Z_VALUE_TAG) && rootHandler instanceof XYZDatasetHandler) || (qName.equals(Y_VALUE_TAG) && rootHandler instanceof XYDatasetHandler)) {
+	    if (qName.equals(Z_VALUE_TAG) && rootHandler instanceof XYZDatasetHandler) {
+		this.itemHandler.setZValue(value);
+	    } else if (qName.equals(Y_VALUE_TAG) && rootHandler instanceof XYZDatasetHandler) {
+		this.itemHandler.setYValue(value);
+	    }
+
+            this.rootHandler.popSubHandler();
+            this.rootHandler.pushSubHandler(
+                new XYZValueHandler(this.rootHandler, this.itemHandler)
+            );
+	} else if (qName.equals(X_VALUE_TAG) || (qName.equals(Y_VALUE_TAG) && rootHandler instanceof XYZDatasetHandler)) {
+	    if (qName.equals(X_VALUE_TAG)) {
+		this.itemHandler.setXValue(value);
+	    } else if (qName.equals(Y_VALUE_TAG)) {
+		this.itemHandler.setYValue(value);
+	    }
+            this.rootHandler.popSubHandler();
+	} else if (qName.equals(ITEM_TAG)) {
+	    this.itemHandler.addSeriesItem();
+            this.rootHandler.popSubHandler();
+        }
+        else {
+            throw new SAXException("Expecting </Item>, </X>, </Y>, or </Z> but found " + qName);
+        }
+
+    }
+
+    /**
+     * Receives some (or all) of the text in the current element.
+     *
+     * @param ch  character buffer.
+     * @param start  the start index.
+     * @param length  the length of the valid character data.
+     */
+    @Override
+    public void characters(char[] ch, int start, int length) {
+        if (this.currentText != null) {
+            this.currentText.append(String.copyValueOf(ch, start, length));
+        }
+    }
+
+    /**
+     * Returns the current text of the textbuffer.
+     *
+     * @return The current text.
+     */
+    protected String getCurrentText() {
+        return this.currentText.toString();
+    }
+
+    /**
+     * Removes all text from the textbuffer at the end of a CDATA section.
+     */
+    protected void clearCurrentText() {
+        this.currentText.delete(0, this.currentText.length());
+    }
+
+}


### PR DESCRIPTION
- Adding support for and a XML reader for XYDataset and XYZDataset, e.g.
  &lt;XYZDataset&gt;
  &lt;Series name="S1"&gt;&lt;Item&gt;&lt;X&gt;1.5&lt;/X&gt;&lt;Y&gt;2.5&lt;/Y&gt;&lt;Z&gt;0.25&lt;/Z&gt;&lt;/Item&gt;&lt;/Series&gt;&lt;/XYZDataset&gt;
- Adding new charts based on XYDataset and XYZDataset: ScatterPlot, XYAreaChart, XYBarChart, XYLineChart, BubbleChart.
- Adding new configuration options: foregroundAlpha, rangeLowerMargin, rangeUpperMargin, domainLowerMargin (NumberAxis only), domainUpperMargin (NumberAxis only), domainLowerBound (NumberAxis only), domainUpperBound (NumberAxis only), rangeAutoRangeIncludesZero, domainAutoRangeIncludesZero (NumberAxis only), rangeZeroBaselineVisible, domainZeroBaselineVisible (NumberAxis only), rangeIntegerTickUnits, domainIntegerTickUnits (NumberAxis only), rangeGridlinesVisible, domainGridlinesVisible, and for Scatter plot: dotHeight, dotWidth.
