### PR TITLE
Allow configuration of MultiplePiePlot and avoid NPE in setSectionColors...

### DIFF
--- a/java/src/org/exist/xquery/modules/jfreechart/JFreeChartFactory.java
+++ b/java/src/org/exist/xquery/modules/jfreechart/JFreeChartFactory.java
@@ -396,8 +396,14 @@ public class JFreeChartFactory {
 		rangeAxis.setStandardTickUnits(NumberAxis.createIntegerTickUnits());
 	    }
 	    rangeAxis.setAutoRangeIncludesZero(config.isRangeAutoRangeIncludesZero());
-	} else 	if (chart.getPlot() instanceof PiePlot) {
-	    PiePlot plot = (PiePlot) chart.getPlot();
+	} else 	if (chart.getPlot() instanceof PiePlot ||
+		    chart.getPlot() instanceof MultiplePiePlot) {
+	    PiePlot plot;
+            if (chart.getPlot() instanceof MultiplePiePlot) {
+                plot = (PiePlot) ((MultiplePiePlot) chart.getPlot()).getPieChart().getPlot();
+	    } else {
+		plot = (PiePlot) chart.getPlot();
+	    }
 	    if (config.getForegroundAlpha() != null) {
 		plot.setForegroundAlpha(config.getForegroundAlpha());
 	    }
@@ -508,7 +514,7 @@ public class JFreeChartFactory {
                 Color color = null;
                 try {
                     color = Colour.getColor( colorName );
-                } catch( XPathException e ) {              
+                } catch( XPathException e ) {
                 }
                    
                 if( color != null ) {
@@ -578,10 +584,14 @@ public class JFreeChartFactory {
         String sectionColorsDelimiter = config.getSectionColorsDelimiter();
         
         if( sectionColors != null ) {
-            PiePlot plot = ((PiePlot)chart.getPlot());
+	    PiePlot plot;
+	    if (chart.getPlot() instanceof MultiplePiePlot) {
+                plot = (PiePlot) ((MultiplePiePlot) chart.getPlot()).getPieChart().getPlot();
+	    } else {
+		plot = (PiePlot) chart.getPlot();
+	    }
             
             StringTokenizer st = new StringTokenizer( sectionColors, sectionColorsDelimiter );
-            
             while( st.hasMoreTokens() ) {
                 String sectionName = st.nextToken().trim();
                 String colorName = "";
@@ -594,10 +604,9 @@ public class JFreeChartFactory {
                 
                 try {
                     color = Colour.getColor( colorName );
-                } 
-                catch( XPathException e ) {              
+                } catch( XPathException e ) {
                 }
-                   
+
                 if( color != null ) {
                     plot.setSectionPaint(sectionName, color);
 


### PR DESCRIPTION
...() if plot is MultiplePiePlot. Method setSectionColors() taking values, key _and_ colour, from <sectionColors> does not work as expected I would say, so need to think about that and add a solution later.
