### PR TITLE
Adding Ivy-dependency batik-util and setSeriesColors for XYItemRenderer (XYPlot)

### DIFF
--- a/config/library/exist.xml.tmpl
+++ b/config/library/exist.xml.tmpl
@@ -4,6 +4,7 @@
 	<jar>batik-awt-util-1.7.jar</jar>
 	<jar>batik-dom-1.7.jar</jar>
 	<jar>batik-svggen-1.7.jar</jar>
+	<jar>batik-util-1.7.jar</jar>
 	<jar>jcommon-1.0.23.jar</jar>
 	<jar>jfreechart-1.0.19.jar</jar>
 	

--- a/ivy.xml
+++ b/ivy.xml
@@ -10,7 +10,9 @@
 
 		<dependency org="org.apache.xmlgraphics" name="batik-svggen" rev="1.7" transitive="false"/>
         <dependency org="org.apache.xmlgraphics" name="batik-dom" rev="1.7" transitive="false"/>
-		<!-- <dependency org="org.apache.xmlgraphics" name="batik-svg-dom" rev="1.7" transitive="false"/> -->
+	<!-- <dependency org="org.apache.xmlgraphics" name="batik-svg-dom" rev="1.7" transitive="false"/> -->
+	<!-- org.apache.batik.util.SVGConstants -->
+	<dependency org="org.apache.xmlgraphics" name="batik-util" rev="1.7" transitive="false"/>
         <dependency org="org.apache.xmlgraphics" name="batik-awt-util" rev="1.7" transitive="false"/>
 
 		<exclude module="servlet-api"/>

--- a/java/src/org/exist/xquery/modules/jfreechart/JFreeChartFactory.java
+++ b/java/src/org/exist/xquery/modules/jfreechart/JFreeChartFactory.java
@@ -48,6 +48,7 @@ import org.jfree.chart.renderer.category.CategoryItemRenderer;
 import org.jfree.chart.renderer.category.LineAndShapeRenderer;
 import org.jfree.chart.renderer.xy.XYDotRenderer;
 import org.jfree.chart.renderer.xy.XYBarRenderer;
+import org.jfree.chart.renderer.xy.XYItemRenderer;
 import org.jfree.chart.title.LegendTitle;
 import org.jfree.chart.title.TextTitle;
 import org.jfree.data.category.CategoryDataset;
@@ -442,7 +443,7 @@ public class JFreeChartFactory {
 		}
 		rangeAxis.setAutoRangeIncludesZero(config.isRangeAutoRangeIncludesZero());
 	    }
-            
+            setSeriesColors(chart, config);
         } else if (chart.getPlot() instanceof PiePlot  || chart.getPlot() instanceof MultiplePiePlot) {
             PiePlot piePlot;
             if (chart.getPlot() instanceof MultiplePiePlot) {
@@ -564,6 +565,9 @@ public class JFreeChartFactory {
 
         if (chart.getPlot() instanceof SpiderWebPlot) {
             setSeriesColors((SpiderWebPlot) chart.getPlot(), seriesColors);
+        } else if (chart.getPlot() instanceof XYPlot) {
+	    XYItemRenderer renderer = ((XYPlot) chart.getPlot()).getRenderer();
+            setSeriesColors(renderer, seriesColors);
         } else {
             CategoryItemRenderer renderer = ((CategoryPlot) chart.getPlot()).getRenderer();
             setSeriesColors(renderer, seriesColors);
@@ -583,7 +587,9 @@ public class JFreeChartFactory {
 
                     if (renderer instanceof SpiderWebPlot) {
                         ((SpiderWebPlot) renderer).setSeriesPaint(i, color);
-                    } else {
+		    } else if (renderer instanceof XYItemRenderer) {
+                        ((XYItemRenderer) renderer).setSeriesPaint(i, color);
+		    } else {
                         ((CategoryItemRenderer) renderer).setSeriesPaint(i, color);
                     }
                     


### PR DESCRIPTION
- Adding ivy dependency batik-util since org.apache.batik.util.SVGConstants used by svgGenerator was missing.
- Adding setSeriesColors to XYItemRenderer (XYPlot) charts.
