### PR TITLE
Make the Stroke use CAP_BUTT and JOIN_MITER if lineWidth is specified for XYLineChart.

### DIFF
--- a/java/src/org/exist/xquery/modules/jfreechart/JFreeChartFactory.java
+++ b/java/src/org/exist/xquery/modules/jfreechart/JFreeChartFactory.java
@@ -494,7 +494,7 @@ public class JFreeChartFactory {
 	    if (config.getLineWidth() != null) {
 		int seriesCount = XYPlot.getDataset().getSeriesCount();
 		for (int i = 0; i < seriesCount; i++) {
-		    XYPlot.getRenderer().setSeriesStroke(i, new BasicStroke(config.getLineWidth()));
+		    XYPlot.getRenderer().setSeriesStroke(i, new BasicStroke(config.getLineWidth(), BasicStroke.CAP_BUTT, BasicStroke.JOIN_MITER));
 		}
 	    }
         }


### PR DESCRIPTION
Otherwise half the line width with CAP_SQUARE on both sides of an interval gap could protrude and cover the gap completely. 
